### PR TITLE
fix: update board name from seeeduino_xiao_ble to xiao_ble

### DIFF
--- a/config/west.yml
+++ b/config/west.yml
@@ -7,7 +7,7 @@ manifest:
   projects:
     - name: zmk
       remote: zmkfirmware
-      revision: main
+      revision: v0.3-branch
       import: app/west.yml
     - name: zmk-pmw3610-driver
       remote: kumamuk-git


### PR DESCRIPTION
## Summary
- ZMKのmainブランチでボード名が `seeeduino_xiao_ble` から `xiao_ble` にリネームされたため、build.yamlとroBa.zmk.ymlを更新

## Test plan
- [ ] CIビルドが成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)